### PR TITLE
Add acl-private param when uploading files to s3

### DIFF
--- a/mysqltos3.sh
+++ b/mysqltos3.sh
@@ -88,7 +88,7 @@ echo "*************** Done compressing the backup file. ***********************"
 
 # upload all databases
 echo "*************** Uploading the new backup... *****************************"
-s3cmd put -f ${BACKUP_PATH}${BACKUP_DIRNAME}${DATESTAMP}.tar.gz s3://${S3BUCKET}/${S3PATH}${CURRENT}/
+s3cmd put --acl-private -f ${BACKUP_PATH}${BACKUP_DIRNAME}${DATESTAMP}.tar.gz s3://${S3BUCKET}/${S3PATH}${CURRENT}/
 echo "*************** New backup uploaded. ************************************"
 
 # Remove old backups from 2 periods ago, if period is month or week, plus daily differential backups


### PR DESCRIPTION
In order for the backup files not to be publicly available (since they
may containe sensitive data), this commit adds the extra param
`--acl-private` that ensures that only the user can access the file
being uploaded